### PR TITLE
fix: grab version from metadata

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -77,7 +77,6 @@
             UV_PYTHON_DOWNLOADS = "never";
           };
           shellHook = ''
-            exec fish
             unset PYTHONPATH
             export REPO_ROOT=$(git rev-parse --show-toplevel)
             uv sync

--- a/src/git_alert/argument_parser.py
+++ b/src/git_alert/argument_parser.py
@@ -1,5 +1,6 @@
 from argparse import ArgumentParser, Namespace
 from pathlib import Path
+from importlib.metadata import version
 
 
 def argument_parser(args) -> Namespace:
@@ -37,7 +38,12 @@ def argument_parser(args) -> Namespace:
         help="colon separated list of paths to ignore",
     )
 
-    parser.add_argument("-v", "--version", action="version", version="%(prog)s 0.4.2")
+    parser.add_argument(
+        "-v",
+        "--version",
+        action="version",
+        version=f"%(prog)s {version('git_alert')}",
+    )
 
     parser.add_argument(
         "-c",


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update

## Description

Pull version number from metadata rather than having it be hardcoded.

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- Related Issue #22 
- Closes #22 

## Added/updated tests?

_It is encouraged to keep the code coverage percentage at 80% and above._

- [ ] Yes
- [x] No, and this is why: not affected
- [ ] I need help with writing tests